### PR TITLE
feat: Add support for maximum number of NAT Gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ module "network" {
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_subnets_availability_zones"></a> [subnets\_availability\_zones](#input\_subnets\_availability\_zones) | Availability zones for the subnets. | `list(string)` | <pre>[<br>  "us-east-1a",<br>  "us-east-1b"<br>]</pre> | no |
 | <a name="input_subnets_ipv4_cidr_block"></a> [subnets\_ipv4\_cidr\_block](#input\_subnets\_ipv4\_cidr\_block) | IPv4 CIDR Block for the subnets. | `list(string)` | <pre>[<br>  "10.0.0.0/16"<br>]</pre> | no |
+| <a name="input_subnets_max_nats"></a> [subnets\_max\_nats](#input\_subnets\_max\_nats) | Upper limit on number of NAT Gateways/Instances to create. Set to 1 or 2 for cost savings at the expense of availability. | `number` | `999` | no |
 | <a name="input_subnets_nat_gateway_enabled"></a> [subnets\_nat\_gateway\_enabled](#input\_subnets\_nat\_gateway\_enabled) | Set to `true` to create a nat gateway in each subnet. | `bool` | `false` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
 | <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -22,6 +22,7 @@ module "subnets" {
   ipv4_cidr_block     = var.subnets_ipv4_cidr_block
   availability_zones  = var.subnets_availability_zones
   nat_gateway_enabled = var.subnets_nat_gateway_enabled
+  max_nats            = var.subnets_max_nats
 
   context = module.this.context
 }

--- a/variables.tf
+++ b/variables.tf
@@ -22,8 +22,15 @@ variable "subnets_nat_gateway_enabled" {
   description = "Set to `true` to create a nat gateway in each subnet."
 }
 
+variable "subnets_max_nats" {
+  type        = number
+  default     = 999
+  description = "Upper limit on number of NAT Gateways/Instances to create. Set to 1 or 2 for cost savings at the expense of availability."
+}
+
 variable "s3_endpoint_enabled" {
   type        = bool
   default     = false
   description = "Set to `true` to create a VPC gateway endpoint for S3."
 }
+


### PR DESCRIPTION
## Proposed Changes
 - [ ] Bug fix
 - [x] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [x] Documentation content changes
 - [ ] Other, please describe:


## What is the current behavior?
It is not possible to set the upper limit on the number of Nat Gateways that will be created by the template. If enabled, 1 gateway will be created per availibility zone.


## What is the new behavior?
It is now possible to set an upper limit on the number of Nat Gateways. This can help keep lower the cost but will also lower the availibility of the app.


## Checklist

Please check that your PR fulfills the following requirements:

- [x] Documentation has been added/updated.
- [ ] Automated tests for the changes have been added/updated.
- [x] Commits have been squashed (if applicable).
- [ ] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).

